### PR TITLE
Feat/connect navigation

### DIFF
--- a/front/App.tsx
+++ b/front/App.tsx
@@ -1,32 +1,40 @@
-import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
-import { Routes, Route,  NativeRouter } from "react-router-native";
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import AuthContextProvider from './store/auth-context';
 import Login from './pages/Login.tsx';
 import Signup from './pages/Signup.tsx';
-import Test1 from './test/pages/Test1.tsx';
 import BottomNavigationPage from './pages/BottomNavigationPage.tsx';
-import FindEmail from './pages/FindEmail.tsx';
-import FindPw from './pages/FindPw.tsx';
 import Home from './pages/Home.tsx';
 import BasicInfoPage from './pages/BasicInfoPage.tsx';
+import FaceInfoPage from './pages/FaceInfoPage.tsx';
+import FaceFeaturePage from './pages/FaceFeaturePage.tsx';
+import FindEmail from './pages/FindEmail.tsx';
+import FindPw from './pages/FindPw.tsx';
 
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import SelfProduce from './pages/SelfProduce.tsx';
+
+const Stack = createStackNavigator();
 function App() {
   return (
     <AuthContextProvider>
       <SafeAreaProvider>
-        <NativeRouter>
-          <Routes>
-            <Route path={"/login"} element={<SafeAreaView><Login/></SafeAreaView>}/>
-            <Route path={"/signup"} element={<SafeAreaView><Signup/></SafeAreaView>}/>
-            <Route path={"/findemail"} element={<SafeAreaView><FindEmail/></SafeAreaView>}/>
-            <Route path={"/findpw"} element={<SafeAreaView><FindPw/></SafeAreaView>}/>
-            <Route path={'/main'} element={<BottomNavigationPage/>}/>
-            <Route path={'/'} element={<Home/>}/>
-            <Route path={'/basic-info'} element={<BasicInfoPage/>}/>
+        <NavigationContainer>
+          <Stack.Navigator initialRouteName='Home' screenOptions={{headerShown: false}}>
+            <Stack.Screen name="Login" component={Login}/>
+            <Stack.Screen name="FindEmail" component={FindEmail}/>
+            <Stack.Screen name="FindPw" component={FindPw}/>
+            <Stack.Screen name="Signup" component={Signup}/>
+            <Stack.Screen name='Main' component={BottomNavigationPage}/>
+            <Stack.Screen name='Home' component={Home}/>
+            <Stack.Screen name='BasicInfo' component={BasicInfoPage}/>
+            <Stack.Screen name='FaceInfo' component={FaceInfoPage}/>
+            <Stack.Screen name='FaceFeature' component={FaceFeaturePage}/>
+            <Stack.Screen name='SelfProduce' component={SelfProduce}/>
             {/* Bottom Navigation이 있는 페이지의 경우 SafeAreaView를 이용하면 ios에서 bottomNavigation이 제대로 안 보임 */}
-          </Routes>
-        </NativeRouter>
-    </SafeAreaProvider>  
+          </Stack.Navigator>
+        </NavigationContainer>
+      </SafeAreaProvider>  
     </AuthContextProvider>
   );
 }

--- a/front/package.json
+++ b/front/package.json
@@ -13,10 +13,11 @@
   "dependencies": {
     "@miblanchard/react-native-slider": "^2.6.0",
     "@react-native-async-storage/async-storage": "^1.23.1",
+    "@react-navigation/compat": "^5.3.20",
     "@react-navigation/material-bottom-tabs": "^6.2.28",
     "@react-navigation/native": "^6.1.17",
-    "@types/uuid": "^9.0.8",
     "@react-navigation/stack": "^6.3.29",
+    "@types/uuid": "^9.0.8",
     "axios": "^1.6.8",
     "react": "18.2.0",
     "react-native": "0.73.6",
@@ -32,7 +33,6 @@
     "react-native-safe-area-context": "^4.9.0",
     "react-native-screens": "^3.29.0",
     "react-native-vector-icons": "^10.0.3",
-    "react-router-native": "^6.22.3",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/front/pages/BasicInfoPage.tsx
+++ b/front/pages/BasicInfoPage.tsx
@@ -1,10 +1,9 @@
 import { useState, useEffect, useContext } from "react";
-import { View, Text, StyleSheet, ScrollView, SafeAreaView } from "react-native";
-import { useNavigate } from "react-router-native";
+import { View, Text, StyleSheet, ScrollView, SafeAreaView, BackHandler } from "react-native";
 import { Card } from "react-native-paper";
 
 import IconText from "../components/IconText";
-import Title from "../components/HeaderBar";
+import HeaderBar from "../components/HeaderBar";
 import CustomTextInput from "../components/CustomTextInput";
 import CustomButton from "../components/CustomButton";
 import CustomSlider from "../components/CustomSlider";
@@ -16,10 +15,10 @@ import { ageDegree, ageGroup, heightGroup, region, gender, HeightGroup, Gender, 
 import { isErrorResponse, isValidResponse, putBasicInfo } from "../util/auth";
 import SelectableTag from "../components/SelectableTag";
 import { createAlertMessage } from "../util/alert";
+import CustomBackHandler from "../components/CustomBackHandler";
 
-const BasicInfoPage = () => {
+const BasicInfoPage = ({navigation}: any) => {
   const authCtx = useContext(AuthContext);
-  const navigate = useNavigate();
   
   interface BasicInfo {
     nickname: string;         
@@ -48,7 +47,9 @@ const BasicInfoPage = () => {
   })
 
   const handlePrevPage = () => {
-    if (pageIndex === 0) return;
+    if (pageIndex === 0) {
+      navigation.goBack();
+    }
     setPageIndex(pageIndex - 1);
   }
 
@@ -128,7 +129,7 @@ const BasicInfoPage = () => {
       );  
       if (isValidResponse(response)) {
         createAlertMessage("기본 정보 입력이 완료되었습니다.");
-        navigate("/main");
+        navigation.goBack();
       }
       if (isErrorResponse(response)) {
         createAlertMessage(response.message);
@@ -329,7 +330,8 @@ const BasicInfoPage = () => {
 
   return (
     <SafeAreaView style={{ flex: 1 }}>
-      <Title onPress={handlePrevPage}>기본 정보</Title>
+      <CustomBackHandler onBack={handlePrevPage}/>
+      <HeaderBar onPress={handlePrevPage}>기본 정보</HeaderBar>
       <View style={styles.container}>
         <View style={styles.innerContainer}>
           <Card style={styles.card}>

--- a/front/pages/BottomNavigationPage.tsx
+++ b/front/pages/BottomNavigationPage.tsx
@@ -11,7 +11,6 @@ const Tab = createMaterialBottomTabNavigator();
 const Test1 = () => {
   return (
     <View style={{height: "100%"}}>
-    <NavigationContainer>
       <PaperProvider theme={{version: 2}}>
         <Tab.Navigator 
           shifting={true}
@@ -32,7 +31,6 @@ const Test1 = () => {
             }}/>
         </Tab.Navigator>
       </PaperProvider>
-    </NavigationContainer>
     </View>
   );
 };

--- a/front/pages/BottomNavigationPage.tsx
+++ b/front/pages/BottomNavigationPage.tsx
@@ -1,6 +1,5 @@
 import { Icon, PaperProvider } from "react-native-paper";
 import { createMaterialBottomTabNavigator } from '@react-navigation/material-bottom-tabs';
-import { NavigationContainer } from '@react-navigation/native';
 import { View } from "react-native";
 import SubTest1 from '../test/pages/SubTest1.tsx';
 import SelfProduce from "./SelfProduce.tsx";

--- a/front/pages/FaceFeaturePage.tsx
+++ b/front/pages/FaceFeaturePage.tsx
@@ -10,12 +10,10 @@ import { getFaceInfo, isFaceInfoDefaultResponse, isFaceInfoResponse } from '../u
 import { AuthContext } from '../store/auth-context.tsx';
 import { createAlertMessage } from '../util/alert.tsx';
 import { IconButton } from 'react-native-paper';
-import { useNavigate } from 'react-router-native';
 
-const FaceFeaturePage = () => {
+const FaceFeaturePage = ({navigation}: any) => {
   // auth와 페이지 전환을 위한 method
   const authCtx = useContext(AuthContext);
-  const navigate = useNavigate();
 
   // 이미지 uri path
   const [ uri, setUri ] = useState('');
@@ -86,7 +84,7 @@ const FaceFeaturePage = () => {
   const clickButton = async () => {
     if (pageIndex === contents.length - 1) {
       // 메인 페이지로 이동
-      createAlertMessage("관상 분석 내용은 프로필에서 다시 볼 수 있습니다", () => navigate('/main'))
+      createAlertMessage("관상 분석 내용은 프로필에서 다시 볼 수 있습니다", () => navigation.goBack())
     } else {
       // ai 관상 이미지 생성
       

--- a/front/pages/FaceInfoPage.tsx
+++ b/front/pages/FaceInfoPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useContext, useEffect } from 'react';
-import { View, Text, StyleSheet, ScrollView, Image, Pressable } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, Image, Pressable, SafeAreaView } from 'react-native';
 import CustomButton from '../components/CustomButton.tsx';
 
 import { colors } from '../assets/colors.tsx';
@@ -10,15 +10,13 @@ import { isFaceInfoResponse, postFaceInfo } from '../util/auth.tsx';
 import { AuthContext } from '../store/auth-context.tsx';
 import { createAlertMessage } from '../util/alert.tsx';
 import AutoHeightImage from 'react-native-auto-height-image';
-import { useNavigate } from 'react-router-native';
 
-const FaceInfoPage = () => {
+const FaceInfoPage = ({navigation}: any) => {
   // 이미지 uri path
   const [ uri, setUri ] = useState('');
 
   // auth와 페이지 전환을 위한 method
   const authCtx = useContext(AuthContext);
-  const navigate = useNavigate();
 
   // 관상 생성 과정 이미지 자동 height 설정
   const [ exImageWidth, setExImageWidth ] = useState(0);
@@ -78,10 +76,11 @@ const FaceInfoPage = () => {
 
         if (isFaceInfoResponse(response)) {
           console.log(response);
-          createAlertMessage("이미지 생성이 오래 걸려, 생성이 다 되면, 프로필에서 보실 수 있습니다", ()=>{navigate('/facefeature')})
+          createAlertMessage("이미지 생성이 오래 걸려, 생성이 다 되면, 프로필에서 보실 수 있습니다", 
+          ()=>{navigation.goBack()})
         } else {
           createAlertMessage(response.message, () => {
-            createAlertMessage("이미지 생성이 오래 걸리기 때문에, 생성이 다 되면, 프로필에서 보실 수 있습니다", ()=>{navigate('/facefeature')})
+            createAlertMessage("이미지 생성이 오래 걸리기 때문에, 생성이 다 되면, 프로필에서 보실 수 있습니다", ()=>{navigation.goBack()})
           });
           // 임시
         }
@@ -115,23 +114,25 @@ const FaceInfoPage = () => {
     </View>
   );
   const setImageStyleContent = (
-    <View style={styles.contentContainer}>
-      <IconText 
-        icon={{source: 'chat-question', color: colors.gray7}} 
-        containerStyle={styles.hintContainer}
-        textStyle={{fontSize: 14, color: colors.gray7}}>마스크에 적용하고 싶은 그림 스타일을 선택해주세요!</IconText>
-      {
-        styleImages.map((styleImage) => {
-          return (
-            <Pressable onPress={() => handleSelectedId(styleImage.id)}>
-              <Image key={styleImage.id} height={150} width={150} 
-                blurRadius={(styleImage.id === selectedStyleId || selectedStyleId === -1) ? 0 : 5}
-                style={styles.styleImage} source={{uri: styleImage.uri}}/>
-            </Pressable>
-          );
-        })
-      }
-    </View>
+    <SafeAreaView>
+      <View style={styles.contentContainer}>
+        <IconText 
+          icon={{source: 'chat-question', color: colors.gray7}} 
+          containerStyle={styles.hintContainer}
+          textStyle={{fontSize: 14, color: colors.gray7}}>마스크에 적용하고 싶은 그림 스타일을 선택해주세요!</IconText>
+        {
+          styleImages.map((styleImage) => {
+            return (
+              <Pressable key={styleImage.id} onPress={() => handleSelectedId(styleImage.id)}>
+                <Image height={150} width={150} 
+                  blurRadius={(styleImage.id === selectedStyleId || selectedStyleId === -1) ? 0 : 5}
+                  style={styles.styleImage} source={{uri: styleImage.uri}}/>
+              </Pressable>
+            );
+          })
+        }
+      </View>
+    </SafeAreaView>
   );
 
   // 카메라에서 image를 가져오면 버튼 클릭 가능하게 수정

--- a/front/pages/FindEmail.tsx
+++ b/front/pages/FindEmail.tsx
@@ -1,9 +1,7 @@
 import { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, ScrollView } from 'react-native';
-import { useNavigate } from "react-router-native";
 
 import { colors } from '../assets/colors.tsx';
-import CustomBackHandler from '../components/CustomBackHandler.tsx';
 import CustomTextInput from '../components/CustomTextInput.tsx';
 import CustomButton from '../components/CustomButton.tsx';
 import { createAlertMessage } from '../util/alert.tsx';
@@ -11,9 +9,7 @@ import { findEmail, isErrorResponse, isFindEmailResponse } from "../util/auth.ts
 import IconText from '../components/IconText.tsx';
 
 
-const FindEmail = () => {
-  const navigate = useNavigate();
-
+const FindEmail = ({navigation}: any) => {
   // email state 관리와 
   const [email, setEmail] = useState({
     value: "",
@@ -57,7 +53,7 @@ const FindEmail = () => {
     const response = await findEmail(email.value);
 
     if (isFindEmailResponse(response)) {
-      createAlertMessage(response.message, () => navigate('/'));
+      createAlertMessage(response.message, () => navigation.goBack());
     }
     if (isErrorResponse(response)){ // 나머지 에러
       createAlertMessage(response.message);
@@ -71,7 +67,6 @@ const FindEmail = () => {
 
   return (
     <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={{ flexGrow: 1, padding: 45, minHeight: '100%'}}>
-      <CustomBackHandler onBack={() => navigate('/')}/>
       <View style={styles.container}>
         <Text style={styles.helperText}>이메일을 입력해주세요</Text>
         <Text style={styles.smallHelperText}>가입 시 등록했던 이메일을 입력하면 가입 여부를 알려드려요.</Text>

--- a/front/pages/FindPw.tsx
+++ b/front/pages/FindPw.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, Dimensions, TextInput } from 'react-native';
-import { useNavigate } from "react-router-native";
 
 import { colors } from '../assets/colors.tsx';
 import CustomBackHandler from '../components/CustomBackHandler.tsx';
@@ -11,9 +10,8 @@ import { isErrorResponse, isValidResponse, sendTemporaryPassword, verifyTemporar
 import IconText from '../components/IconText.tsx';
 
 
-const FindPw = () => {
+const FindPw = ({navigation}: any) => {
   const height = Dimensions.get('window').height;
-  const navigate = useNavigate();
   const [pageIndex, setPageIndex] = useState(0);
 
   const [email, setEmail] = useState({
@@ -116,7 +114,7 @@ const FindPw = () => {
       const response = await verifyTemporaryPassword(email.value, tempPassword.value, password.value[0], password.value[1]);
       
       if (isValidResponse(response)) {
-        createAlertMessage(response.message, () => navigate('/'));
+        createAlertMessage(response.message, () => navigation.goBack());
       }
       if (isErrorResponse(response)) {
         createAlertMessage(response.message);
@@ -125,7 +123,7 @@ const FindPw = () => {
   }
 
   function onBack() {
-    if (pageIndex === 0) navigate('/');
+    if (pageIndex === 0) navigation.goBack();
     else setPageIndex(0);
   }
 

--- a/front/pages/Home.tsx
+++ b/front/pages/Home.tsx
@@ -1,16 +1,19 @@
-import { useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import { View } from "react-native"
 import AutoHeightImage from 'react-native-auto-height-image';
-import { useNavigate } from "react-router-native";
 
 import { AuthContext } from '../store/auth-context.tsx';
-import { getBasicInfo, isBasicInfoResponse, isErrorResponse, isValidResponse } from "../util/auth";
+import { getBasicInfo, getFaceInfo, isBasicInfoResponse, isErrorResponse, isFaceInfoResponse, isValidResponse } from "../util/auth";
 import { createAlertMessage } from "../util/alert.tsx";
+import { useFocusEffect } from "@react-navigation/native";
 
-const Home = () => {
+const Home = ({ navigation }: any) => {
   const authCtx = useContext(AuthContext);
-  const navigate = useNavigate();
   const [reloadCounter, setReloadCounter] = useState(0);
+
+  const [haveBasicInfo, setHaveBasicInfo] = useState(false);
+  const [haveFaceInfo, setHaveFaceInfo] = useState(true);
+  const [haveFaceFeature, setHaveFaceFeature] = useState(false);
   
   const reload = () => {
     setReloadCounter(reloadCounter + 1);
@@ -20,7 +23,7 @@ const Home = () => {
     try {
       const response = await authCtx.signout();
       if (isValidResponse(response)) {
-        navigate('/login');
+        navigation.navigate('Login');
       } 
       else {
         reload();
@@ -57,7 +60,6 @@ const Home = () => {
   }
 
   const handleAuth = async () => {
-
     // 5회 이상 오류 시 로그아웃 후 로그인 창으로 이동
     if (reloadCounter > 5) {
       logoutAndRedirect();
@@ -66,75 +68,144 @@ const Home = () => {
       // 앱 실행시 엑세스토큰이 있는지 체크
       if (authCtx.accessToken) {
         console.log("엑세스토큰 있음");
-        // 기본정보 get 시도
-        console.log("기본정보 로딩 중");
-        const response = await getBasicInfo(authCtx.accessToken);
-        console.log("기본정보 로딩 끝");
-
-        // 기본정보 응답 확인
-        if (isBasicInfoResponse(response)) {
-          // 기본정보 얻음
-          if (response.ageDegree && 
-              response.ageGroup &&
-              response.gender &&
-              response.heightGroup && 
-              response.nickname &&
-              response.region) {
-                console.log("기본정보 있음");
-                navigate("/main");
-              }
-          else {
-            console.log("기본정보 없음");
-            navigate("/basic-info");
-          }
-        } 
-        else {
-          // 오류 시 에러 메세지 출력 후 재시도
-          console.log(response.message);
-          createAlertMessage(response.message, reload);
-        } 
         
-        // 오류 처리
-        if (isErrorResponse(response)) {
-          switch (response.exceptionCode) {
-            case 2004: // EXPIRED_TOKEN 이미 만료된 토큰입니다.
-                if (authCtx.refreshToken) {
-                // 엑세스토큰 재발급 시도
-                console.log("재발급 시도");
-                tryReissue();
-              }
-              else {
-                console.log("리프레시 토큰 없음");
-                navigate("/login");
-              }
-              break;
-            
-            // 토큰 에러 시 
-            case 2002: // SIGNATURE_NOT_FOUND JWT 서명을 확인하지 못했습니다.
-            case 2003: // MALFORMED_TOKEN         토큰의 길이 및 형식이 올바르지 않습니다.
-            case 2005: // UNSUPPORTED_TOKEN       지원되지 않는 토큰입니다.
-            case 2006: // INVALID_TOKEN           토큰이 유효하지 않습니다.
-            case 2007: // BAD_REQUEST_TO_PROVIDER 토큰이 유효하지 않습니다.
-            case 2008: // UNAUTHORIZED            로그인한 정보가 없습니다.
-              console.log("tokenError:", response.message);
-              createAlertMessage(response.message, logoutAndRedirect);
-              break;
-            
-            // 기본정보가 null인 경우
-            case 0: 
-              console.log("nullError:", response.message);
-              break;
+        if (!haveBasicInfo) {
+          // 기본정보 get 시도
+          console.log("기본정보 로딩 중", haveBasicInfo);
+          const response = await getBasicInfo(authCtx.accessToken);
+          console.log("기본정보 로딩 끝");
 
-            // 그 외 통신 오류 등  
-            default:
-              console.log("default:", response.message);
-              createAlertMessage(response.message, reload);
+          // 기본정보 응답 확인
+          if (isBasicInfoResponse(response)) {
+            // 기본정보 얻음
+            if (response.ageDegree && 
+                response.ageGroup &&
+                response.gender &&
+                response.heightGroup && 
+                response.nickname &&
+                response.region) {
+                console.log("기본정보 있음");
+                setHaveBasicInfo(true);
+              }
+            else {
+              console.log("기본정보 없음");
+              navigation.navigate("BasicInfo");
+            }
+          } 
+          else {
+            // 오류 시 에러 메세지 출력 후 재시도
+            console.log(response.message);
+            createAlertMessage(response.message, reload);
+          } 
+
+          if (isErrorResponse(response)) {
+            switch (response.exceptionCode) {
+              case 2004: // EXPIRED_TOKEN 이미 만료된 토큰입니다.
+                  if (authCtx.refreshToken) {
+                  // 엑세스토큰 재발급 시도
+                  console.log("재발급 시도");
+                  tryReissue();
+                }
+                else {
+                  console.log("리프레시 토큰 없음");
+                  navigation.navigate("Login");
+                }
+                break;
+              
+              // 토큰 에러 시 
+              case 2002: // SIGNATURE_NOT_FOUND JWT 서명을 확인하지 못했습니다.
+              case 2003: // MALFORMED_TOKEN         토큰의 길이 및 형식이 올바르지 않습니다.
+              case 2005: // UNSUPPORTED_TOKEN       지원되지 않는 토큰입니다.
+              case 2006: // INVALID_TOKEN           토큰이 유효하지 않습니다.
+              case 2007: // BAD_REQUEST_TO_PROVIDER 토큰이 유효하지 않습니다.
+              case 2008: // UNAUTHORIZED            로그인한 정보가 없습니다.
+                console.log("tokenError:", response.message);
+                createAlertMessage(response.message, logoutAndRedirect);
+                break;
+              
+              // 기본정보가 null인 경우
+              case 0: 
+                console.log("nullError:", response.message);
+                break;
+  
+              // 그 외 통신 오류 등  
+              default:
+                console.log("default:", response.message);
+                createAlertMessage(response.message, reload);
+            }
           }
+        }
+
+        else if (!haveFaceInfo) {
+          // 마스크 이미지 get 시도
+          console.log("마스크 이미지 로딩 중");
+          const response = await getFaceInfo(authCtx.accessToken);
+          console.log("마스크 이미지 로딩 끝");
+
+          // 마스크 이미지 응답 확인
+          if (isFaceInfoResponse(response)) {
+            // 기본정보 얻음
+            if (response.originS3Url !== response.generatedS3Url) {
+              console.log("마스크 이미지 있음");
+              setHaveFaceInfo(true);
+            }
+            else {
+              console.log("마스크 이미지 없음");
+              navigation.navigate("FaceInfo");
+            }
+          } 
+          else {
+            // 오류 시 에러 메세지 출력 후 재시도
+            console.log(response.message);
+            createAlertMessage(response.message, reload);
+          } 
+
+          if (isErrorResponse(response)) {
+            switch (response.exceptionCode) {
+              case 2004: // EXPIRED_TOKEN 이미 만료된 토큰입니다.
+                  if (authCtx.refreshToken) {
+                  // 엑세스토큰 재발급 시도
+                  console.log("재발급 시도");
+                  tryReissue();
+                }
+                else {
+                  console.log("리프레시 토큰 없음");
+                  navigation.navigate("Login");
+                }
+                break;
+              
+              // 토큰 에러 시 
+              case 2002: // SIGNATURE_NOT_FOUND JWT 서명을 확인하지 못했습니다.
+              case 2003: // MALFORMED_TOKEN         토큰의 길이 및 형식이 올바르지 않습니다.
+              case 2005: // UNSUPPORTED_TOKEN       지원되지 않는 토큰입니다.
+              case 2006: // INVALID_TOKEN           토큰이 유효하지 않습니다.
+              case 2007: // BAD_REQUEST_TO_PROVIDER 토큰이 유효하지 않습니다.
+              case 2008: // UNAUTHORIZED            로그인한 정보가 없습니다.
+                console.log("tokenError:", response.message);
+                createAlertMessage(response.message, logoutAndRedirect);
+                break;
+              
+              // 기본정보가 null인 경우
+              case 0: 
+                console.log("nullError:", response.message);
+                break;
+  
+              // 그 외 통신 오류 등  
+              default:
+                console.log("default:", response.message);
+                createAlertMessage(response.message, reload);
+            }
+          }
+        }
+        
+        else if (!haveFaceFeature) {
+          // 관상 분석 get 시도
+          setHaveFaceFeature(true);
         }
       }
       else {
         console.log("엑세스토큰 없음");
-        navigate("/login");
+        navigation.navigate("Login");
       }
     }
     catch {
@@ -142,12 +213,24 @@ const Home = () => {
     }
   }
 
+  useFocusEffect(
+    useCallback(() => {
+      console.log("reloadCounter: " + reloadCounter);
+      if (!authCtx.isLoading) {
+        handleAuth();
+      }
+    }, [reloadCounter, authCtx.isLoading, navigation])
+  );
+
   useEffect(() => {
-    console.log("reloadCounter: " + reloadCounter);
-    if (!authCtx.isLoading) {
-      handleAuth();
+    if (haveBasicInfo && haveFaceInfo && haveFaceFeature) navigation.navigate('Main');
+    else {
+      console.log("reloadCounter: " + reloadCounter);
+      if (!authCtx.isLoading) {
+        handleAuth();
+      }
     }
-  }, [reloadCounter, authCtx.isLoading])
+  }, [haveBasicInfo, haveFaceInfo, haveFaceFeature])
 
   return (
     <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>

--- a/front/pages/Login.tsx
+++ b/front/pages/Login.tsx
@@ -8,11 +8,11 @@ import CustomTextInput from '../components/CustomTextInput.tsx';
 import { AuthContext } from '../store/auth-context.tsx';
 
 import { colors } from '../assets/colors.tsx';
-import { isErrorResponse, isValidResponse, createAlertMessage } from '../util/auth.tsx';
+import { isErrorResponse, isValidResponse } from '../util/auth.tsx';
+import { createAlertMessage } from '../util/alert.tsx';
 
-const Login = () => {
+const Login = ({navigation}: any) => {
   const authCtx = useContext(AuthContext);
-  const navigate = useNavigate();
   const [ email, setEmail ] = useState('');
   const [ pw, setPw ] = useState('');
 
@@ -31,7 +31,7 @@ const Login = () => {
     const response = await authCtx.signin(email, pw);
 
     if (isValidResponse(response)) {
-      navigate('/');
+      navigation.navigate('Home');
     }
     if (isErrorResponse(response)) {
       createAlertMessage(response.message);
@@ -77,11 +77,11 @@ const Login = () => {
 
         {/* 이메일 찾기, 비밀번호 찾기 */}
         <View style={[styles.fit_content, {marginBottom: 40}]}>
-          <TouchableOpacity onPress={() => {navigate('/findemail')}} style={{backgroundColor: colors.transparent}}>
+          <TouchableOpacity onPress={() => {navigation.navigate('FindEmail')}} style={{backgroundColor: colors.transparent}}>
             <Text style={styles.small_button_text}>이메일 찾기</Text>
           </TouchableOpacity>
           <View style={{width: 1, height: '80%', alignSelf: 'center', marginHorizontal: 15, backgroundColor: colors.gray9 }}/>
-          <TouchableOpacity onPress={() => {navigate('/findpw')}} style={{backgroundColor: colors.transparent}}>
+          <TouchableOpacity onPress={() => {navigation.navigate('FindPw')}} style={{backgroundColor: colors.transparent}}>
             <Text style={styles.small_button_text}>비밀번호 찾기</Text>
           </TouchableOpacity>
         </View>
@@ -101,7 +101,7 @@ const Login = () => {
         {/* 회원가입 */}
         <View style={[styles.fit_content, {marginTop: 10}]}>
           <Text style={{alignSelf: "center", color: colors.gray7}}>아직 회원이 아니신가요? </Text>
-          <TouchableOpacity onPress={() => {navigate('/signup')}} style={{backgroundColor: colors.transparent, height: 17.25, marginLeft: 5}}>
+          <TouchableOpacity onPress={() => {navigation.navigate('Signup')}} style={{backgroundColor: colors.transparent, height: 17.25, marginLeft: 5}}>
             <Text style={[styles.small_button_text, styles.underline]}>회원가입</Text>
           </TouchableOpacity>
         </View>

--- a/front/pages/Login.tsx
+++ b/front/pages/Login.tsx
@@ -1,7 +1,6 @@
 import { useRef, useState, useContext } from 'react';
 import { View, Text, StyleSheet, TextInput as RNTextInput, TouchableOpacity } from 'react-native';
 import AutoHeightImage from 'react-native-auto-height-image';
-import { useNavigate } from "react-router-native";
 import CustomButton from '../components/CustomButton.tsx';
 import ImageButton from '../components/ImageButton.tsx';
 import CustomTextInput from '../components/CustomTextInput.tsx';

--- a/front/pages/Signup.tsx
+++ b/front/pages/Signup.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState, useRef } from "react";
 import { View, StyleSheet, Text, Pressable, ScrollView, TextInput } from "react-native";
 import { Icon } from 'react-native-paper';
-import { useNavigate } from "react-router-native";
 
 import IconText from "../components/IconText.tsx";
 import CustomTextInput from "../components/CustomTextInput.tsx";
@@ -13,8 +12,7 @@ import { createAlertMessage } from "../util/alert.tsx";
 
 import VerifyEmailModal from "./VerifyEmailModal.tsx";
 
-const Signup = () => {
-  const navigate = useNavigate();
+const Signup = ({navigation}: any) => {
   const [modalVisible, setModalVisible] = useState(false);
 
   const [email, setEmail] = useState({
@@ -118,7 +116,7 @@ const Signup = () => {
     const response = await signup(email.value, password.value[0], password.value[1], email.status === "VERIFIED");
     if (isValidResponse(response)) {
       createAlertMessage(response.message);
-      navigate('/');
+      navigation.goBack();
     };
   }
   


### PR DESCRIPTION
## 연관된 이슈


## 파트
- FE

## 작업 내용
- 화면 전환 방식 react-router-native에서 stack 방식으로 수정
- Home에서 새로운 창으로 갔다가 돌아오면 다시 코드 실행하게 기능 추가(일단 지금은 ai 서버와 연동 못해서 그냥 넘어가게 구현)

## 기타(특이사항 등)
- react-router-native 라이브러리 대신 @react-navigation 사용
- 다른 창을 갔다가 돌아오는 것을 인식하기 위해, useFocusEffect와 useCallback을 사용

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
