### PR TITLE
fix: resume images null 일 때 반복문 돌지 않고 빈 리스트 반환

### DIFF
--- a/src/main/java/capstone/facefriend/bucket/BucketService.java
+++ b/src/main/java/capstone/facefriend/bucket/BucketService.java
@@ -131,27 +131,24 @@ public class BucketService {
 
         List<String> resumeImageS3urls = new ArrayList<>();
 
-        for (MultipartFile image : images) {
+        if (images != null) {
+            for (MultipartFile image : images) {
+                ObjectMetadata metadata = new ObjectMetadata();
+                metadata.setContentLength(image.getInputStream().available());
+                metadata.setContentType(image.getContentType());
 
-            if (image.isEmpty() || image.getSize() == 0) {
-                return List.of();
+                String imageObjectName = UUID.randomUUID() + resumePostfix;
+
+                amazonS3.putObject(
+                        new PutObjectRequest(
+                                bucketName,
+                                imageObjectName,
+                                image.getInputStream(),
+                                metadata
+                        ).withCannedAcl(CannedAccessControlList.PublicRead)
+                );
+                resumeImageS3urls.add(amazonS3.getUrl(bucketName, imageObjectName).toString());
             }
-
-            ObjectMetadata metadata = new ObjectMetadata();
-            metadata.setContentLength(image.getInputStream().available());
-            metadata.setContentType(image.getContentType());
-
-            String imageObjectName = UUID.randomUUID() + resumePostfix;
-
-            amazonS3.putObject(
-                    new PutObjectRequest(
-                            bucketName,
-                            imageObjectName,
-                            image.getInputStream(),
-                            metadata
-                    ).withCannedAcl(CannedAccessControlList.PublicRead)
-            );
-            resumeImageS3urls.add(amazonS3.getUrl(bucketName, imageObjectName).toString());
         }
         return resumeImageS3urls;
     }


### PR DESCRIPTION
## 연관된 이슈
> resume images null 일 때 반복문 돌지 않고 빈 리스트 반환

## 파트
- [x] BE

## 작업 내용
resume images null 일 때 반복문 돌지 않고 빈 리스트 반환

## 기타(특이사항 등)
> 없음

### 스크린샷 (선택)
> 없음

## 💬리뷰 요구사항(선택)
> 없음

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 없음
