### PR TITLE
refactor: 리프레시 토큰 파싱할 때 NullPointerException 예외처리

### DIFF
--- a/back/src/main/java/capstone/facefriend/auth/infrastructure/JwtProvider.java
+++ b/back/src/main/java/capstone/facefriend/auth/infrastructure/JwtProvider.java
@@ -119,6 +119,8 @@ public class JwtProvider implements TokenProvider {
             }
 
             return claims.get("id", Long.class);
+        } catch (NullPointerException e) { // identifier 키값이 존재하지 않을 경우
+            throw new AuthException(NOT_ACCESS_TOKEN);
         } catch (ExpiredJwtException e) {
             throw new AuthException(EXPIRED_TOKEN);
         } catch (SecurityException e) {
@@ -147,6 +149,8 @@ public class JwtProvider implements TokenProvider {
             }
 
             return claims.get("id", Long.class);
+        } catch (NullPointerException e) { // identifier 키값이 존재하지 않을 경우
+            throw new AuthException(NOT_ACCESS_TOKEN);
         } catch (ExpiredJwtException e) {
             Claims expiredClaims = e.getClaims(); // catch 후 id 를 반환하고 이를 사용해 액세스 토큰을 추출할 수 있습니다.
             return expiredClaims.get("id", Long.class);


### PR DESCRIPTION
## 리팩토링 내용
### 1. 리프레시 토큰 NullPointerException 예외 처리
- 리프레시 토큰을 파싱할 때 identifier 키값이 존재하지 않아서 NullPointerException 예외가 터졌음
- 해당 예외를 잡고 예외 메시지를 던지도록 예외처리 추가
<br>
