### PR TITLE
refactor: 이미지 생성 로직을 트랜잭션으로부터 분리

### DIFF
--- a/back/src/main/java/capstone/facefriend/auth/infrastructure/JwtProvider.java
+++ b/back/src/main/java/capstone/facefriend/auth/infrastructure/JwtProvider.java
@@ -39,7 +39,7 @@ public class JwtProvider implements TokenProvider {
 
     private final RedisDao redisDao;
 
-    private static final long ACCESS_TOKEN_EXPIRATION_TIME = 60 * 60 * 3L; // 3시간
+    private static final long ACCESS_TOKEN_EXPIRATION_TIME = 60 * 60 * 24 * 7L; // 7일 // 60 * 60 * 3L; // 3시간
     private static final long REFRESH_TOKEN_EXPIRATION_TIME = 60 * 60 * 24 * 7L; // 7일
 
     @PostConstruct

--- a/back/src/main/java/capstone/facefriend/auth/infrastructure/JwtProvider.java
+++ b/back/src/main/java/capstone/facefriend/auth/infrastructure/JwtProvider.java
@@ -39,7 +39,7 @@ public class JwtProvider implements TokenProvider {
 
     private final RedisDao redisDao;
 
-    private static final long ACCESS_TOKEN_EXPIRATION_TIME = 60 * 60 * 24 * 7L; // 7일 // 60 * 60 * 3L; // 3시간
+    private static final long ACCESS_TOKEN_EXPIRATION_TIME = 60 * 60 * 3L; // 3시간
     private static final long REFRESH_TOKEN_EXPIRATION_TIME = 60 * 60 * 24 * 7L; // 7일
 
     @PostConstruct

--- a/back/src/main/java/capstone/facefriend/bucket/BucketService.java
+++ b/back/src/main/java/capstone/facefriend/bucket/BucketService.java
@@ -62,6 +62,7 @@ public class BucketService {
     private final ChatRoomMemberRepository chatRoomMemberRepository;
 
     // FaceInfo : origin 업로드 & generated 업로드
+    @TimeTrace
     public List<String> uploadOriginAndGenerated(
             MultipartFile origin,
             ByteArrayMultipartFile generated
@@ -120,7 +121,6 @@ public class BucketService {
         return amazonS3.getUrl(BUCKET_NAME, generatedObjectName).toString();
     }
 
-    // FaceInfo : origin 수정 -> generated 수정
     @TimeTrace
     public List<String> updateOriginAndGenerated(
             MultipartFile origin,
@@ -140,7 +140,6 @@ public class BucketService {
         return uploadOriginAndGenerated(origin, generated);
     }
 
-    // FaceInfo : origin 삭제 -> generated 삭제
     public String deleteOriginAndGenerated(
             Long memberId
     ) {
@@ -157,8 +156,6 @@ public class BucketService {
         return DEFAULT_FACE_INFO_S3_URL;
     }
 
-
-    // Resume : images 업로드
     public List<String> uploadResumeImages(
             List<MultipartFile> images
     ) throws IOException {
@@ -187,7 +184,6 @@ public class BucketService {
         return resumeImageS3urls;
     }
 
-    // Resume : images 삭제 -> images 업로드
     public List<String> updateResumeImages(
             List<MultipartFile> images,
             Resume resume
@@ -196,7 +192,6 @@ public class BucketService {
         return uploadResumeImages(images);
     }
 
-    // Resume : images 삭제
     public void deleteResumeImages(
             Resume resume
     ) {

--- a/back/src/main/java/capstone/facefriend/chat/aop/ChatAop.java
+++ b/back/src/main/java/capstone/facefriend/chat/aop/ChatAop.java
@@ -11,6 +11,7 @@ import capstone.facefriend.member.domain.member.Member;
 import capstone.facefriend.member.repository.MemberRepository;
 import capstone.facefriend.member.exception.member.MemberException;
 import capstone.facefriend.member.multipartFile.ByteArrayMultipartFile;
+import capstone.facefriend.member.service.FaceInfoRequestor;
 import capstone.facefriend.member.service.FaceInfoService;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GetObjectRequest;
@@ -43,6 +44,7 @@ public class ChatAop {
 
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final FaceInfoService faceInfoService;
+    private final FaceInfoRequestor faceInfoRequestor;
     private final MemberRepository memberRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final AmazonS3 amazonS3;
@@ -160,32 +162,32 @@ public class ChatAop {
 
         switch (chatMessageCount) {
             case LEVEL_TWO: // 5
-                ByteArrayMultipartFile senderGeneratedByLevelTwo = faceInfoService.generateByLevel(senderOrigin, senderId, senderStyleId, 2);
+                ByteArrayMultipartFile senderGeneratedByLevelTwo = faceInfoRequestor.generateByLevel(senderOrigin, senderId, senderStyleId, 2);
                 String senderGeneratedByLevelTwoS3url = bucketService.updateGeneratedByLevel(senderGeneratedByLevelTwo, roomId);
                 senderFaceInfoByLevel.setGeneratedByLevelS3url(senderGeneratedByLevelTwoS3url); // dirty check
                 break;
             case LEVEL_THREE: // 10
-                ByteArrayMultipartFile receiverGeneratedByLevelTwo = faceInfoService.generateByLevel(receiverOrigin, receiverId, receiverStyleId, 2);
+                ByteArrayMultipartFile receiverGeneratedByLevelTwo = faceInfoRequestor.generateByLevel(receiverOrigin, receiverId, receiverStyleId, 2);
                 String receiverGeneratedByLevelTwoS3url = bucketService.updateGeneratedByLevel(receiverGeneratedByLevelTwo, roomId);
                 receiverFaceInfoByLevel.setGeneratedByLevelS3url(receiverGeneratedByLevelTwoS3url); // dirty check
                 break;
             case LEVEL_FOUR: // 15
-                ByteArrayMultipartFile senderGeneratedByLevelThree = faceInfoService.generateByLevel(senderOrigin, senderId, senderStyleId, 3);
+                ByteArrayMultipartFile senderGeneratedByLevelThree = faceInfoRequestor.generateByLevel(senderOrigin, senderId, senderStyleId, 3);
                 String senderGeneratedByLevelThreeS3url = bucketService.updateGeneratedByLevel(senderGeneratedByLevelThree, roomId);
                 senderFaceInfoByLevel.setGeneratedByLevelS3url(senderGeneratedByLevelThreeS3url); // dirty check
                 break;
             case LEVEL_FIVE: // 20
-                ByteArrayMultipartFile receiverGeneratedByLevelThree = faceInfoService.generateByLevel(receiverOrigin, receiverId, receiverStyleId, 3);
+                ByteArrayMultipartFile receiverGeneratedByLevelThree = faceInfoRequestor.generateByLevel(receiverOrigin, receiverId, receiverStyleId, 3);
                 String receiverGeneratedByLevelThreeS3url = bucketService.updateGeneratedByLevel(receiverGeneratedByLevelThree, roomId);
                 receiverFaceInfoByLevel.setGeneratedByLevelS3url(receiverGeneratedByLevelThreeS3url); // dirty check
                 break;
             case LEVEL_SIX: // 25
-                ByteArrayMultipartFile senderGeneratedByLevelFour = faceInfoService.generateByLevel(senderOrigin, senderId, senderStyleId, 4);
+                ByteArrayMultipartFile senderGeneratedByLevelFour = faceInfoRequestor.generateByLevel(senderOrigin, senderId, senderStyleId, 4);
                 String senderGeneratedByLevelFourS3url = bucketService.updateGeneratedByLevel(senderGeneratedByLevelFour, roomId);
                 senderFaceInfoByLevel.setGeneratedByLevelS3url(senderGeneratedByLevelFourS3url); // dirty check
                 break;
             case LEVEL_SEVEN: // 30
-                ByteArrayMultipartFile receiverGeneratedByLevelFour = faceInfoService.generateByLevel(receiverOrigin, receiverId, receiverStyleId, 4);
+                ByteArrayMultipartFile receiverGeneratedByLevelFour = faceInfoRequestor.generateByLevel(receiverOrigin, receiverId, receiverStyleId, 4);
                 String receiverGeneratedByLevelFourS3url = bucketService.updateGeneratedByLevel(receiverGeneratedByLevelFour, roomId);
                 receiverFaceInfoByLevel.setGeneratedByLevelS3url(receiverGeneratedByLevelFourS3url); // dirty check
                 break;

--- a/back/src/main/java/capstone/facefriend/member/controller/FaceInfoController.java
+++ b/back/src/main/java/capstone/facefriend/member/controller/FaceInfoController.java
@@ -1,18 +1,22 @@
 package capstone.facefriend.member.controller;
 
 import capstone.facefriend.auth.controller.support.AuthMember;
-import capstone.facefriend.common.aop.TimeTrace;
-import capstone.facefriend.member.service.FaceInfoService;
+import capstone.facefriend.bucket.BucketService;
 import capstone.facefriend.member.dto.faceInfo.FaceInfoResponse;
+import capstone.facefriend.member.exception.faceInfo.FaceInfoException;
+import capstone.facefriend.member.service.FaceInfoRequestor;
+import capstone.facefriend.member.service.FaceInfoService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.context.request.async.DeferredResult;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static capstone.facefriend.member.exception.faceInfo.FaceInfoExceptionType.FAIL_TO_GENERATE;
 
 @Slf4j
 @RestController
@@ -20,28 +24,34 @@ import java.util.concurrent.CompletableFuture;
 public class FaceInfoController {
 
     private final FaceInfoService faceInfoService;
+    private final BucketService bucketService;
+    private final FaceInfoRequestor faceInfoRequestor;
 
     @GetMapping("/face-info")
-    public ResponseEntity<FaceInfoResponse> get(
+    public ResponseEntity<FaceInfoResponse> getOriginAndGenerated(
             @AuthMember Long memberId
     ) {
         return ResponseEntity.ok(faceInfoService.getOriginAndGenerated(memberId));
     }
 
     @PutMapping("/face-info")
-    @TimeTrace
-    public DeferredResult<ResponseEntity<FaceInfoResponse>> updateOriginAndGenerated(
-            @RequestPart("origin")MultipartFile origin,
+    public ResponseEntity<FaceInfoResponse> updateOriginAndGenerated(
+            @RequestPart("origin") MultipartFile origin,
             @RequestParam("styleId") Integer styleId,
             @AuthMember Long memberId
     ) {
-        DeferredResult<ResponseEntity<FaceInfoResponse>> deferredResult = new DeferredResult<>();
+        CompletableFuture<List<String>> futureS3Urls = CompletableFuture
+                .supplyAsync(() -> faceInfoRequestor.generate(origin, styleId, memberId))
+                .thenApply(generated -> bucketService.updateOriginAndGenerated(origin, generated, memberId));
 
-        CompletableFuture
-                .supplyAsync(() -> faceInfoService.updateOriginAndGenerated(origin, styleId, memberId))
-                .thenAccept(result -> deferredResult.setResult(ResponseEntity.ok(result)));
+        List<String> s3Urls = null;
+        try {
+            s3Urls = futureS3Urls.get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new FaceInfoException(FAIL_TO_GENERATE);
+        }
 
-        return deferredResult;
+        return ResponseEntity.ok(faceInfoService.updateOriginAndGenerated(s3Urls, memberId));
     }
 
     @DeleteMapping("/face-info")

--- a/back/src/main/java/capstone/facefriend/member/exception/faceInfo/FaceInfoExceptionType.java
+++ b/back/src/main/java/capstone/facefriend/member/exception/faceInfo/FaceInfoExceptionType.java
@@ -5,7 +5,8 @@ import capstone.facefriend.common.exception.Status;
 
 public enum FaceInfoExceptionType implements ExceptionType {
 
-    FAIL_TO_GENERATE(Status.SERVER_ERROR, 8001, "바이트를 추출할 수 없습니다."),
+    FAIL_TO_GENERATE(Status.SERVER_ERROR, 8001, "관상 이미지 생성에 실패했습니다."),
+    FAIL_TO_GET_BYTES(Status.SERVER_ERROR, 8002, "바이트를 추출할 수 없습니다.")
     ;
 
     private final Status status;

--- a/back/src/main/java/capstone/facefriend/member/service/FaceInfoRequestor.java
+++ b/back/src/main/java/capstone/facefriend/member/service/FaceInfoRequestor.java
@@ -1,0 +1,121 @@
+package capstone.facefriend.member.service;
+
+import capstone.facefriend.common.aop.TimeTrace;
+import capstone.facefriend.member.exception.faceInfo.FaceInfoException;
+import capstone.facefriend.member.multipartFile.ByteArrayMultipartFile;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+import static capstone.facefriend.member.exception.faceInfo.FaceInfoExceptionType.FAIL_TO_GET_BYTES;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FaceInfoRequestor {
+
+    @Value("${flask.generate-url}")
+    private String GENERATE_IMAGE_REQUEST_URL;
+    @Value("${flask.generate-by-level-url}")
+    private String GENERATE_IMAGE_BY_LEVEL_REQUEST_URL;
+
+    private final RestTemplate restTemplate;
+
+    @TimeTrace
+    public ByteArrayMultipartFile generate(MultipartFile origin, Integer styleId, Long memberId) {
+        ByteArrayResource resource = null;
+        try {
+            resource = new ByteArrayResource(origin.getBytes()) {
+                @Override
+                public String getFilename() {
+                    return URLEncoder.encode(origin.getOriginalFilename(), StandardCharsets.UTF_8);
+                }
+            };
+        } catch (IOException e) {
+            throw new FaceInfoException(FAIL_TO_GET_BYTES);
+        }
+
+        // body
+        LinkedMultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("image", resource);
+        body.add("style_id", styleId);
+        body.add("user_id", memberId);
+
+        // header
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+        // request entity
+        HttpEntity<LinkedMultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+
+        // response entity
+        ResponseEntity<JsonNode> responseEntity = restTemplate.postForEntity(GENERATE_IMAGE_REQUEST_URL, requestEntity, JsonNode.class); // 문제
+
+        // convert JSON into Map
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, Object> result = objectMapper.convertValue(responseEntity.getBody(), new TypeReference<>() {
+        });
+
+        byte[] imageBinary = Base64.getDecoder().decode((String) result.get("image_binary"));
+
+        return new ByteArrayMultipartFile(imageBinary, origin.getOriginalFilename());
+    }
+
+    public ByteArrayMultipartFile generateByLevel(MultipartFile origin, Long memberId, int styleId, int level) {
+        ByteArrayResource resource = null;
+        try {
+            resource = new ByteArrayResource(origin.getBytes()) {
+                @Override
+                public String getFilename() {
+                    return URLEncoder.encode(origin.getOriginalFilename(), StandardCharsets.UTF_8);
+                }
+            };
+        } catch (IOException e) {
+            throw new FaceInfoException(FAIL_TO_GET_BYTES);
+        }
+
+        // body
+        LinkedMultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("image", resource);
+        body.add("user_id", memberId);
+        body.add("style_id", styleId);
+        body.add("level", level);
+
+        // header
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+        // request entity
+        HttpEntity<LinkedMultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+
+        // response entity
+        ResponseEntity<JsonNode> responseEntity = restTemplate.postForEntity(GENERATE_IMAGE_BY_LEVEL_REQUEST_URL, requestEntity, JsonNode.class);
+
+        // convert JSON into Map
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, Object> result = objectMapper.convertValue(responseEntity.getBody(), new TypeReference<>() {
+        });
+
+        byte[] imageBinary = Base64.getDecoder().decode((String) result.get("image_binary"));
+
+        return new ByteArrayMultipartFile(imageBinary, origin.getOriginalFilename());
+    }
+}


### PR DESCRIPTION
## 리팩토링 내용
### 1. 이미지 생성 로직을 트랜잭션으로부터 분리
- FaceInfoService 클래스의 generate() 를 FaceInfoRequestor 클래스로로 이동
- 비동기 처리를 FaceInfoController 단에서 구현

<br>

### 2. 추가 내용 : 해결 과정
1. 인공지능 서버에 관상 이미지 생성을 요청하면 응답까지 평균 15초가 소요됨.
2. 성능 개선을 위해 자바의 CompletableFuture, DeferredResult 를 사용하여 이미지 생성을 비동기 처리하였음.
3. 하지만 오히려 커넥션 타임아웃 에러가 발생했음.
4. 에러의 원인이 쓰레드가 다른 작업을 처리하기 위해 최대 풀 사이즈를 초과한 커넥션을 요청하기 때문임을 파악함.
5. 이미지 생성이 트랜잭션에 묶여있기 때문에 오랜 시간 커넥션을 반환하지 않는 것으로 유추하고 코드를 수정하였음.
6. Jmeter 로 테스트를 했을 때, 에러 발생률 0% 결과를 얻었지만 서비스 시간 및 Throughput의 성능 개선은 없었음.
7. 스프링 OSIV 기본값이 true 이기 때문에 이미지 생성을 트랜잭션으로부터 분리하더라도 Filter에 다다라서 커넥션을 반환한다는 것을 파악함.
8. OSIV 를 false 로 바꾼 후 이미지 생성(비동기 미적용 시 임계점 요청 12개)과 이미지 조회(요청 50,100,150,200개) 동시 테스트를 진행한 결과, 이미지 조회에서 평균 서비스 시간이 98% 감소하고, 평균 Throughput이 약 2900% 증가하는 성능 개선을 얻을 수 있었음.

<br>

### 3. 첨부
![Group 1218](https://github.com/kookmin-sw/capstone-2024-18/assets/102044895/43e44ee0-0493-431a-b373-d92cdeffdb51)
![Group 1219 (1)](https://github.com/kookmin-sw/capstone-2024-18/assets/102044895/8b4753ef-4397-473b-b42f-6d4f5e27f349)
