### PR TITLE
refactor: 쿼리 최적화를 위한 로딩전략 수정

### DIFF
--- a/back/src/main/java/capstone/facefriend/DummyInitializer.java
+++ b/back/src/main/java/capstone/facefriend/DummyInitializer.java
@@ -1,175 +1,81 @@
 package capstone.facefriend;
 
 import capstone.facefriend.member.domain.analysisInfo.AnalysisInfo;
+import capstone.facefriend.member.domain.basicInfo.BasicInfo;
+import capstone.facefriend.member.domain.faceInfo.FaceInfo;
 import capstone.facefriend.member.domain.member.Member;
+import capstone.facefriend.member.domain.member.Role;
 import capstone.facefriend.member.repository.AnalysisInfoRepository;
+import capstone.facefriend.member.repository.BasicInfoRepository;
+import capstone.facefriend.member.repository.FaceInfoRepository;
 import capstone.facefriend.member.repository.MemberRepository;
 import capstone.facefriend.member.service.MemberService;
-import capstone.facefriend.member.dto.member.SignUpRequest;
 import capstone.facefriend.resume.domain.Resume;
 import capstone.facefriend.resume.repository.ResumeRepository;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Random;
-import java.util.stream.Collectors;
+import java.util.Map;
+import java.util.Set;
 
 @Component
 @Slf4j
 @RequiredArgsConstructor
 public class DummyInitializer {
 
-    private final MemberService memberService;
     private final MemberRepository memberRepository;
-
+    private final BasicInfoRepository basicInfoRepository;
+    private final FaceInfoRepository faceInfoRepository;
     private final AnalysisInfoRepository analysisInfoRepository;
     private final ResumeRepository resumeRepository;
+
+    private final PasswordEncoder passwordEncoder;
 
     @PostConstruct
     @Transactional
     public void init() {
-        Random random = new Random();
+        for (int i = 1; i <= 100; i++) {
+            BasicInfo basicInfo = BasicInfo.builder()
+                    .nickname("nickname_" + i)
+                    .gender(BasicInfo.Gender.DEFAULT)
+                    .region(BasicInfo.Region.DEFAULT)
+                    .ageGroup(BasicInfo.AgeGroup.DEFAULT)
+                    .ageDegree(BasicInfo.AgeDegree.DEFAULT)
+                    .heightGroup(BasicInfo.HeightGroup.DEFAULT)
+                    .build();
+            basicInfoRepository.save(basicInfo);
 
-        List<List<String>> CATEGORY = List.of(
-                List.of("FOOD"),
-                List.of("WORKOUT"),
-                List.of("MOVIE"),
-                List.of("FASHION"),
-                List.of("DATING"),
-                List.of("STUDY"),
-                List.of("ETC"),
-                List.of("FOOD", "WORKOUT"),
-                List.of("FOOD", "MOVIE"),
-                List.of("FOOD", "FASHION"),
-                List.of("FOOD", "DATING"),
-                List.of("FOOD", "STUDY"),
-                List.of("FOOD", "ETC"),
-                List.of("WORKOUT", "MOVIE"),
-                List.of("WORKOUT", "FASHION"),
-                List.of("WORKOUT", "DATING"),
-                List.of("WORKOUT", "STUDY"),
-                List.of("WORKOUT", "ETC"),
-                List.of("MOVIE", "FASHION"),
-                List.of("MOVIE", "DATING"),
-                List.of("MOVIE", "STUDY"),
-                List.of("MOVIE", "ETC"),
-                List.of("FASHION", "DATING"),
-                List.of("FASHION", "STUDY"),
-                List.of("FASHION", "ETC"),
-                List.of("DATING", "STUDY"),
-                List.of("DATING", "ETC"),
-                List.of("STUDY", "ETC"),
-                List.of("FOOD", "WORKOUT", "MOVIE"),
-                List.of("FOOD", "WORKOUT", "FASHION"),
-                List.of("FOOD", "WORKOUT", "DATING"),
-                List.of("FOOD", "WORKOUT", "STUDY"),
-                List.of("FOOD", "WORKOUT", "ETC"),
-                List.of("FOOD", "MOVIE", "FASHION"),
-                List.of("FOOD", "MOVIE", "DATING"),
-                List.of("FOOD", "MOVIE", "STUDY"),
-                List.of("FOOD", "MOVIE", "ETC"),
-                List.of("FOOD", "FASHION", "DATING"),
-                List.of("FOOD", "FASHION", "STUDY"),
-                List.of("FOOD", "FASHION", "ETC"),
-                List.of("FOOD", "DATING", "STUDY"),
-                List.of("FOOD", "DATING", "ETC"),
-                List.of("FOOD", "STUDY", "ETC"),
-                List.of("WORKOUT", "MOVIE", "FASHION"),
-                List.of("WORKOUT", "MOVIE", "DATING"),
-                List.of("WORKOUT", "MOVIE", "STUDY"),
-                List.of("WORKOUT", "MOVIE", "ETC"),
-                List.of("WORKOUT", "FASHION", "DATING"),
-                List.of("WORKOUT", "FASHION", "STUDY"),
-                List.of("WORKOUT", "FASHION", "ETC"),
-                List.of("WORKOUT", "DATING", "STUDY"),
-                List.of("WORKOUT", "DATING", "ETC"),
-                List.of("WORKOUT", "STUDY", "ETC"),
-                List.of("MOVIE", "FASHION", "DATING"),
-                List.of("MOVIE", "FASHION", "STUDY"),
-                List.of("MOVIE", "FASHION", "ETC"),
-                List.of("MOVIE", "DATING", "STUDY"),
-                List.of("MOVIE", "DATING", "ETC"),
-                List.of("MOVIE", "STUDY", "ETC"),
-                List.of("FASHION", "DATING", "STUDY"),
-                List.of("FASHION", "DATING", "ETC"),
-                List.of("FASHION", "STUDY", "ETC"),
-                List.of("DATING", "STUDY", "ETC"),
-                List.of("FOOD", "WORKOUT", "MOVIE", "FASHION"),
-                List.of("FOOD", "WORKOUT", "MOVIE", "DATING"),
-                List.of("FOOD", "WORKOUT", "MOVIE", "STUDY"),
-                List.of("FOOD", "WORKOUT", "MOVIE", "ETC"),
-                List.of("FOOD", "WORKOUT", "FASHION", "DATING"),
-                List.of("FOOD", "WORKOUT", "FASHION", "STUDY"),
-                List.of("FOOD", "WORKOUT", "FASHION", "ETC"),
-                List.of("FOOD", "WORKOUT", "DATING", "STUDY"),
-                List.of("FOOD", "WORKOUT", "DATING", "ETC"),
-                List.of("FOOD", "WORKOUT", "STUDY", "ETC"),
-                List.of("FOOD", "MOVIE", "FASHION", "DATING"),
-                List.of("FOOD", "MOVIE", "FASHION", "STUDY"),
-                List.of("FOOD", "MOVIE", "FASHION", "ETC"),
-                List.of("FOOD", "MOVIE", "DATING", "STUDY"),
-                List.of("FOOD", "MOVIE", "DATING", "ETC"),
-                List.of("FOOD", "MOVIE", "STUDY", "ETC"),
-                List.of("FOOD", "FASHION", "DATING", "STUDY"),
-                List.of("FOOD", "FASHION", "DATING", "ETC"),
-                List.of("FOOD", "FASHION", "STUDY", "ETC"),
-                List.of("FOOD", "DATING", "STUDY", "ETC"),
-                List.of("WORKOUT", "MOVIE", "FASHION", "DATING"),
-                List.of("WORKOUT", "MOVIE", "FASHION", "STUDY"),
-                List.of("WORKOUT", "MOVIE", "FASHION", "ETC"),
-                List.of("WORKOUT", "MOVIE", "DATING", "STUDY"),
-                List.of("WORKOUT", "MOVIE", "DATING", "ETC"),
-                List.of("WORKOUT", "MOVIE", "STUDY", "ETC"),
-                List.of("WORKOUT", "FASHION", "DATING", "STUDY"),
-                List.of("WORKOUT", "FASHION", "DATING", "ETC"),
-                List.of("WORKOUT", "FASHION", "STUDY", "ETC"),
-                List.of("WORKOUT", "DATING", "STUDY", "ETC"),
-                List.of("MOVIE", "FASHION", "DATING", "STUDY"),
-                List.of("MOVIE", "FASHION", "DATING", "ETC"),
-                List.of("MOVIE", "FASHION", "STUDY", "ETC"),
-                List.of("MOVIE", "DATING", "STUDY", "ETC"),
-                List.of("FASHION", "DATING", "STUDY", "ETC"),
-                List.of("FOOD", "WORKOUT", "MOVIE", "FASHION", "DATING"),
-                List.of("FOOD", "WORKOUT", "MOVIE", "FASHION", "STUDY"),
-                List.of("FOOD", "WORKOUT", "MOVIE", "FASHION", "ETC"),
-                List.of("FOOD", "WORKOUT", "MOVIE", "DATING", "STUDY"),
-                List.of("FOOD", "WORKOUT", "MOVIE", "DATING", "ETC"),
-                List.of("FOOD", "WORKOUT", "MOVIE", "STUDY", "ETC"),
-                List.of("FOOD", "WORKOUT", "FASHION", "DATING", "STUDY"),
-                List.of("FOOD", "WORKOUT", "FASHION", "DATING", "ETC"),
-                List.of("FOOD", "WORKOUT", "FASHION", "STUDY", "ETC"),
-                List.of("FOOD", "WORKOUT", "DATING", "STUDY", "ETC"),
-                List.of("FOOD", "MOVIE", "FASHION", "DATING", "STUDY"),
-                List.of("FOOD", "MOVIE", "FASHION", "DATING", "ETC"),
-                List.of("FOOD", "MOVIE", "FASHION", "STUDY", "ETC"),
-                List.of("FOOD", "MOVIE", "DATING", "STUDY", "ETC"),
-                List.of("FOOD", "FASHION", "DATING", "STUDY", "ETC"),
-                List.of("WORKOUT", "MOVIE", "FASHION", "DATING", "STUDY"),
-                List.of("WORKOUT", "MOVIE", "FASHION", "DATING", "ETC"),
-                List.of("WORKOUT", "MOVIE", "FASHION", "STUDY", "ETC"),
-                List.of("WORKOUT", "MOVIE", "DATING", "STUDY", "ETC"),
-                List.of("WORKOUT", "FASHION", "DATING", "STUDY", "ETC"),
-                List.of("MOVIE", "FASHION", "DATING", "STUDY", "ETC")
-        );
+            FaceInfo faceInfo = FaceInfo.builder()
+                    .originS3url("")
+                    .generatedS3url("")
+                    .build();
+            faceInfoRepository.save(faceInfo);
 
-        for (int i = 1; i <= 50; i++) {
-            // 회원 가입
-            memberService.signUp(new SignUpRequest(i + "@" + i + ".com", "123", "123"));
-            Member member = memberRepository.findByEmail(i + "@" + i + ".com").get();
-
-            // 관상 분석
-            AnalysisInfo analysisInfo = member.getAnalysisInfo();
-            analysisInfo.setFaceShapeIdNum(random.nextInt(5)); // 얼굴형 넘버 랜덤
+            AnalysisInfo analysisInfo = AnalysisInfo.builder()
+                    .analysisFull(Map.of("", ""))
+                    .analysisShort(List.of(""))
+                    .faceShapeIdNum(i % 5)
+                    .build();
             analysisInfoRepository.save(analysisInfo);
 
-            // 자기소개서
+            Member member = Member.builder()
+                    .email(i + "@" + i + ".com")
+                    .password(passwordEncoder.encode("123"))
+                    .role(Role.USER)
+                    .basicInfo(basicInfo)
+                    .faceInfo(faceInfo)
+                    .analysisInfo(analysisInfo)
+                    .build();
+            memberRepository.save(member);
+
             Resume resume = Resume.builder()
-                    .categories(CATEGORY.get(random.nextInt(CATEGORY.size() - 1)).stream().map(str -> Resume.Category.valueOf(str)).collect(Collectors.toSet())) // 카테고리 랜던
                     .member(member)
+                    .categories(i % 5 == 0 ? Set.of(Resume.Category.MOVIE) : Set.of(Resume.Category.DATING))
                     .build();
             resumeRepository.save(resume);
         }

--- a/back/src/main/java/capstone/facefriend/member/domain/member/Member.java
+++ b/back/src/main/java/capstone/facefriend/member/domain/member/Member.java
@@ -40,15 +40,15 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private Role role;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "BASIC_INFO_ID", nullable = false)
     private BasicInfo basicInfo;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "FACE_INFO_ID", nullable = false)
     private FaceInfo faceInfo;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "ANALYSIS_INFO_ID", nullable = false)
     private AnalysisInfo analysisInfo;
 

--- a/back/src/main/java/capstone/facefriend/resume/domain/Resume.java
+++ b/back/src/main/java/capstone/facefriend/resume/domain/Resume.java
@@ -35,19 +35,12 @@ public class Resume {
     private List<String> resumeImageS3urls;
 
     @Builder.Default
-    @ElementCollection(fetch = FetchType.EAGER)
+    @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "CATEGORIES", joinColumns = @JoinColumn(name = "RESUME_ID"))
     @Enumerated(EnumType.STRING)
     private Set<Category> categories = new HashSet<>();
 
     private String content;
-
-    @Builder.Default
-    @ElementCollection
-    @CollectionTable(name = "OPEN_MEMBER", joinColumns = @JoinColumn(name = "RESUME_ID"))
-    @MapKeyColumn(name = "MEMBER_ID") // key
-    @Column(name = "IS_OPEN") // value
-    private Map<Long, Boolean> friends = new HashMap<>(); // 타멤버id : 공개여부
 
     public enum Category {
         FOOD("음식"),

--- a/back/src/main/java/capstone/facefriend/resume/repository/ResumeRepositoryImpl.java
+++ b/back/src/main/java/capstone/facefriend/resume/repository/ResumeRepositoryImpl.java
@@ -1,5 +1,6 @@
 package capstone.facefriend.resume.repository;
 
+import capstone.facefriend.common.aop.TimeTrace;
 import capstone.facefriend.member.domain.member.Member;
 import capstone.facefriend.member.domain.member.QMember;
 import capstone.facefriend.member.exception.member.MemberException;
@@ -34,6 +35,7 @@ public class ResumeRepositoryImpl implements ResumeRepositoryCustom {
     private static final List<Integer> GOOD_COMBI_IN_CASE_4 = List.of(0, 3); // 토
 
     // 좋은 궁합 동적 쿼리
+    @TimeTrace
     public Page<ResumeHomeDetailResponse> getResumesByGoodCombi(Long memberId, Pageable pageable) {
         Member me = findMemberById(memberId);
         Integer faceShapeIdNum = me.getAnalysisInfo().getFaceShapeIdNum();
@@ -62,7 +64,7 @@ public class ResumeRepositoryImpl implements ResumeRepositoryCustom {
                         resume.id.as("resumeId"),
                         resume.member.faceInfo.generatedS3url.as("thumbnailS3url")))
                 .from(resume)
-                .leftJoin(resume.member, QMember.member) // left join
+                .innerJoin(resume.member, QMember.member) // left join
                 .where(builder) // boolean builder
                 .where(resume.member.ne(me))
                 .orderBy(resume.id.desc())
@@ -73,7 +75,7 @@ public class ResumeRepositoryImpl implements ResumeRepositoryCustom {
         int total = queryFactory
                 .select(resume)
                 .from(resume)
-                .leftJoin(resume.member, QMember.member) // left join
+                .innerJoin(resume.member, QMember.member) // left join
                 .where(builder) // boolean builder
                 .fetch()
                 .size();
@@ -82,6 +84,7 @@ public class ResumeRepositoryImpl implements ResumeRepositoryCustom {
     }
 
     // 카테고리별 동적 쿼리
+    @TimeTrace
     public Page<ResumeHomeDetailResponse> getResumesByCategory(Long memberId, String category, Pageable pageable) {
         Member me = findMemberById(memberId);
 
@@ -90,7 +93,7 @@ public class ResumeRepositoryImpl implements ResumeRepositoryCustom {
                         resume.id.as("resumeId"),
                         resume.member.faceInfo.generatedS3url.as("thumbnailS3url")))
                 .from(resume)
-                .leftJoin(resume.member, QMember.member) // left join
+                .innerJoin(resume.member, QMember.member) // left join
                 .where(resume.categories.contains(Resume.Category.valueOf(category)))
                 .where(resume.member.ne(me))
                 .orderBy(resume.id.desc())
@@ -101,7 +104,7 @@ public class ResumeRepositoryImpl implements ResumeRepositoryCustom {
         int total = queryFactory
                 .select(resume)
                 .from(resume)
-                .leftJoin(resume.member, QMember.member) // left join
+                .innerJoin(resume.member, QMember.member) // left join
                 .where(resume.categories.contains(Resume.Category.valueOf(category)))
                 .fetch()
                 .size();


### PR DESCRIPTION
## 리팩토링 내용

![Group 1236 (3)](https://github.com/kookmin-sw/capstone-2024-18/assets/102044895/d9c0df1d-77da-43d2-9437-df9598121e29)

### 1. 관상 궁합별 추천, 카테고리별 추천 (조회) 쿼리 최적화
- 유저 조회시, 1:1 연관관계를 가진 엔티티(기본정보, 관상 이미지, 관상 분석)까지 조회되어 JOIN이 3회 발생.
- 관상 궁합별 추천에 필요한 엔티티(관상 분석)를 제외하고 나머지는 지연로딩으로 전략 변경.
    - 결과 : JOIN 횟수 3회 → 2회로 감소.
- 페이지네이션을 위한 카운트 쿼리 작성시, 1:N 연관관계를 가진 값타입(카테고리)이 즉시로딩으로 설정되어있던 탓에 SELECT가 n회 발생.
- 값타입 로딩전략을 지연로딩으로 변경.
    - 결과 : SELECT 횟수 n회 → 0회로 감소.
- 테스트 결과, 관상 궁합별 추천 실행시간 평균 56% 감소, 카테고리별 추천 실행시간 평균 43% 감소.
<br>