### PR TITLE
refactor: 관상 분석 로직을 트랜잭션으로부터 분리

### DIFF
--- a/back/src/main/java/capstone/facefriend/member/exception/analysis/AnalysisInfoException.java
+++ b/back/src/main/java/capstone/facefriend/member/exception/analysis/AnalysisInfoException.java
@@ -3,9 +3,9 @@ package capstone.facefriend.member.exception.analysis;
 import capstone.facefriend.common.exception.BaseException;
 import capstone.facefriend.common.exception.ExceptionType;
 
-public class AnalysisException extends BaseException {
+public class AnalysisInfoException extends BaseException {
 
-    public AnalysisException(ExceptionType exceptionType) {
+    public AnalysisInfoException(ExceptionType exceptionType) {
         super(exceptionType);
     }
 }

--- a/back/src/main/java/capstone/facefriend/member/exception/analysis/AnalysisInfoExceptionType.java
+++ b/back/src/main/java/capstone/facefriend/member/exception/analysis/AnalysisInfoExceptionType.java
@@ -4,18 +4,20 @@ package capstone.facefriend.member.exception.analysis;
 import capstone.facefriend.common.exception.ExceptionType;
 import capstone.facefriend.common.exception.Status;
 
-public enum AnalysisExceptionType implements ExceptionType {
+public enum AnalysisInfoExceptionType implements ExceptionType {
 
     FAIL_TO_ANALYSIS(Status.NOT_FOUND, 6001, "관상 분석에 실패했습니다."),
     FAIL_TO_DESERIALIZE_ANALYSIS(Status.BAD_REQUEST, 6002, "관성 분석 역직렬화에 실패했습니다."),
-    FAIL_TO_EXTRACT_FACE_SHAPE_ID_NUM(Status.BAD_REQUEST, 6003, "관성 분석 역직렬화에 실패했습니다.")
+    FAIL_TO_EXTRACT_FACE_SHAPE_ID_NUM(Status.BAD_REQUEST, 6003, "관성 분석 역직렬화에 실패했습니다."),
+    FAIL_TO_GET_BYTES(Status.SERVER_ERROR, 6004, "바이트를 추출할 수 없습니다."),
+    FAIL_TO_GET_RESPONSE_BODY(Status.SERVER_ERROR, 6005, "응답 바디를 읽을 수 없습니다.")
     ;
 
     private final Status status;
     private final int exceptionCode;
     private final String message;
 
-    AnalysisExceptionType(Status status, int exceptionCode, String message) {
+    AnalysisInfoExceptionType(Status status, int exceptionCode, String message) {
         this.status = status;
         this.exceptionCode = exceptionCode;
         this.message = message;

--- a/back/src/main/java/capstone/facefriend/member/repository/AnalysisInfoRepository.java
+++ b/back/src/main/java/capstone/facefriend/member/repository/AnalysisInfoRepository.java
@@ -1,10 +1,12 @@
 package capstone.facefriend.member.repository;
 
+import capstone.facefriend.common.aop.TimeTrace;
 import capstone.facefriend.member.domain.analysisInfo.AnalysisInfo;
 import org.springframework.data.repository.Repository;
 
 public interface AnalysisInfoRepository extends Repository<AnalysisInfo, Long> {
 
+    @TimeTrace
     AnalysisInfo save(AnalysisInfo analysisInfo);
 
     AnalysisInfo findAnalysisInfoById(Long id);

--- a/back/src/main/java/capstone/facefriend/member/repository/FaceInfoRepository.java
+++ b/back/src/main/java/capstone/facefriend/member/repository/FaceInfoRepository.java
@@ -1,10 +1,12 @@
 package capstone.facefriend.member.repository;
 
+import capstone.facefriend.common.aop.TimeTrace;
 import capstone.facefriend.member.domain.faceInfo.FaceInfo;
 import org.springframework.data.repository.Repository;
 
 public interface FaceInfoRepository extends Repository<FaceInfo, Long> {
 
+    @TimeTrace
     FaceInfo save(FaceInfo faceInfo);
 
     FaceInfo findFaceInfoById(Long id);

--- a/back/src/main/java/capstone/facefriend/member/service/AnalysisInfoRequestor.java
+++ b/back/src/main/java/capstone/facefriend/member/service/AnalysisInfoRequestor.java
@@ -1,0 +1,80 @@
+package capstone.facefriend.member.service;
+
+import capstone.facefriend.common.aop.TimeTrace;
+import capstone.facefriend.member.exception.analysis.AnalysisInfoException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import static capstone.facefriend.member.exception.analysis.AnalysisInfoExceptionType.*;
+import static capstone.facefriend.member.service.AnalysisInfoService.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AnalysisInfoRequestor {
+
+    @Value("${flask.analyze-url}")
+    private String requestUrl;
+
+    private final RestTemplate restTemplate;
+
+    @TimeTrace
+    public AnalysisInfoTotal analyze(MultipartFile origin, Long memberId) {
+
+        // convert MultipartFile into ByteArrayResource
+        ByteArrayResource resource;
+        try {
+            resource = new ByteArrayResource(origin.getBytes()) {
+                @Override
+                public String getFilename() {
+                    return URLEncoder.encode(origin.getOriginalFilename(), StandardCharsets.UTF_8);
+                }
+            };
+        } catch (IOException e) {
+            throw new AnalysisInfoException(FAIL_TO_GET_BYTES);
+        }
+
+        // body
+        LinkedMultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("image", resource);
+        body.add("user_id", memberId);
+
+        // header
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+        // request entity
+        HttpEntity<LinkedMultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+        // response entity
+        ResponseEntity<String> responseEntity = restTemplate.exchange(
+                requestUrl,
+                HttpMethod.POST,
+                requestEntity,
+                String.class
+        );
+
+        // map JSON into AnalysisInfoTotal
+        ObjectMapper objectMapper = new ObjectMapper();
+        AnalysisInfoTotal analysisInfoTotal;
+        try {
+            analysisInfoTotal = objectMapper.readValue(responseEntity.getBody(), AnalysisInfoTotal.class);
+        } catch (JsonProcessingException e) {
+            throw new AnalysisInfoException(FAIL_TO_GET_RESPONSE_BODY);
+        }
+
+        return analysisInfoTotal;
+    }
+}

--- a/back/src/main/java/capstone/facefriend/member/service/FaceInfoRequestor.java
+++ b/back/src/main/java/capstone/facefriend/member/service/FaceInfoRequestor.java
@@ -41,7 +41,8 @@ public class FaceInfoRequestor {
 
     @TimeTrace
     public ByteArrayMultipartFile generate(MultipartFile origin, Integer styleId, Long memberId) {
-        ByteArrayResource resource = null;
+        // convert MultipartFile into ByteArrayResource
+        ByteArrayResource resource;
         try {
             resource = new ByteArrayResource(origin.getBytes()) {
                 @Override
@@ -80,7 +81,8 @@ public class FaceInfoRequestor {
     }
 
     public ByteArrayMultipartFile generateByLevel(MultipartFile origin, Long memberId, int styleId, int level) {
-        ByteArrayResource resource = null;
+        // convert MultipartFile into ByteArrayResource
+        ByteArrayResource resource;
         try {
             resource = new ByteArrayResource(origin.getBytes()) {
                 @Override

--- a/back/src/main/java/capstone/facefriend/member/service/FaceInfoService.java
+++ b/back/src/main/java/capstone/facefriend/member/service/FaceInfoService.java
@@ -1,6 +1,7 @@
 package capstone.facefriend.member.service;
 
 import capstone.facefriend.bucket.BucketService;
+import capstone.facefriend.common.aop.TimeTrace;
 import capstone.facefriend.member.domain.faceInfo.FaceInfo;
 import capstone.facefriend.member.domain.member.Member;
 import capstone.facefriend.member.dto.faceInfo.FaceInfoResponse;
@@ -31,6 +32,7 @@ public class FaceInfoService {
         return new FaceInfoResponse(faceInfo.getOriginS3url(), faceInfo.getGeneratedS3url());
     }
 
+    @TimeTrace
     @Transactional
     public FaceInfoResponse updateOriginAndGenerated(List<String> s3Urls, Long memberId) {
 

--- a/back/src/main/java/capstone/facefriend/member/service/deserializer/StringListDeserializer.java
+++ b/back/src/main/java/capstone/facefriend/member/service/deserializer/StringListDeserializer.java
@@ -1,6 +1,6 @@
 package capstone.facefriend.member.service.deserializer;
 
-import capstone.facefriend.member.exception.analysis.AnalysisException;
+import capstone.facefriend.member.exception.analysis.AnalysisInfoException;
 import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
@@ -11,7 +11,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import static capstone.facefriend.member.exception.analysis.AnalysisExceptionType.FAIL_TO_DESERIALIZE_ANALYSIS;
+import static capstone.facefriend.member.exception.analysis.AnalysisInfoExceptionType.FAIL_TO_DESERIALIZE_ANALYSIS;
 import static com.fasterxml.jackson.core.JsonToken.START_ARRAY;
 import static com.fasterxml.jackson.core.JsonToken.VALUE_STRING;
 
@@ -19,13 +19,13 @@ import static com.fasterxml.jackson.core.JsonToken.VALUE_STRING;
 public class StringListDeserializer extends JsonDeserializer<List<String>> {
 
     @Override
-    public List<String> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
+    public List<String> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
         JsonToken jt = p.getCurrentToken();
         if (jt == START_ARRAY) {
             return p.readValueAs(List.class);
         } else if (jt == VALUE_STRING) {
             return Arrays.asList(p.getValueAsString());
         }
-        throw new AnalysisException(FAIL_TO_DESERIALIZE_ANALYSIS);
+        throw new AnalysisInfoException(FAIL_TO_DESERIALIZE_ANALYSIS);
     }
 }


### PR DESCRIPTION
## 리팩토링 내용

### 1. 관상 분석 로직을 트랜잭션으로부터 분리
- AnalysisInfoService 클래스의 analyze() 를 AnalysisInfoRequestor 클래스로로 이동
- 비동기 처리를 AnalysisInfoController 단에서 구현
- CompletableFuture 예외처리는 private 메서드로 따로 분리하여 코드 가독성 향상